### PR TITLE
remove destination account owner enforcement

### DIFF
--- a/programs/ext_swap/src/instructions/swap.rs
+++ b/programs/ext_swap/src/instructions/swap.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 use m_ext::cpi::accounts::{Unwrap, Wrap};
 use m_ext::state::{EXT_GLOBAL_SEED, MINT_AUTHORITY_SEED, M_VAULT_SEED};
@@ -65,11 +64,8 @@ pub struct Swap<'info> {
     )]
     pub from_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(
-        init_if_needed,
-        payer = signer,
-        associated_token::mint = to_mint,
-        associated_token::authority = signer,
-        associated_token::token_program = to_token_program,
+        token::mint = to_mint,
+        token::token_program = to_token_program,
     )]
     pub to_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(
@@ -144,7 +140,6 @@ pub struct Swap<'info> {
     /// CHECK: checked against whitelisted extensions
     #[account(constraint = to_ext_program.key() != from_ext_program.key())]
     pub to_ext_program: UncheckedAccount<'info>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/programs/ext_swap/src/instructions/unwrap.rs
+++ b/programs/ext_swap/src/instructions/unwrap.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 use m_ext::cpi::accounts::Unwrap as ExtUnwrap;
 use m_ext::state::{EXT_GLOBAL_SEED, MINT_AUTHORITY_SEED, M_VAULT_SEED};
@@ -46,11 +45,8 @@ pub struct Unwrap<'info> {
      * Token Accounts
      */
     #[account(
-        init_if_needed,
-        payer = signer,
-        associated_token::mint = m_mint,
-        associated_token::authority = signer,
-        associated_token::token_program = m_token_program,
+        token::mint = m_mint,
+        token::token_program = m_token_program,
     )]
     pub m_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(
@@ -101,7 +97,6 @@ pub struct Unwrap<'info> {
      */
     /// CHECK: checked against whitelisted extensions
     pub from_ext_program: UncheckedAccount<'info>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/programs/ext_swap/src/instructions/wrap.rs
+++ b/programs/ext_swap/src/instructions/wrap.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 use m_ext::cpi::accounts::Wrap as ExtWrap;
 use m_ext::state::{EXT_GLOBAL_SEED, MINT_AUTHORITY_SEED, M_VAULT_SEED};
@@ -52,11 +51,8 @@ pub struct Wrap<'info> {
     )]
     pub m_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(
-        init_if_needed,
-        payer = signer,
-        associated_token::mint = to_mint,
-        associated_token::authority = signer,
-        associated_token::token_program = to_token_program,
+        token::mint = to_mint,
+        token::token_program = to_token_program,
     )]
     pub to_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
@@ -100,7 +96,6 @@ pub struct Wrap<'info> {
      */
     /// CHECK: checked against whitelisted extensions
     pub to_ext_program: UncheckedAccount<'info>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 


### PR DESCRIPTION
Doesn't really need to be enforced.
Also, need to be able to unwrap to temp $M accounts (that the caller might not own). 