### PR TITLE
imp: Housekeeping after Dawn deployment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -10,9 +10,21 @@ USDKY="op://Solana Dev/Solana Program Keys/program-keypair-2"
 USDP="op://Solana Dev/Solana Program Keys/program-keypair-3"
 XO="op://Solana Dev/Solana Program Keys/solana-earner-delta-keypair"
 
+# --------------------------
+# Dawn
+DAWN_EXT_PROGRAM_KEYPAIR="op://Solana Dev/Solana Program Keys/solana-earner-theta-keypair"
+DAWN_EXT_MINT_KEYPAIR="op://Solana Dev/Solana Program Keys/dawn-usd"
+DAWN_EXT_NAME="USD.tel"
+DAWN_EXT_SYMBOL="USD.tel"
+DAWN_EXT_URI="https://green-obedient-albatross-155.mypinata.cloud/ipfs/bafkreidyksiobibqsfzjefjlz3nkshgnkk2gangdjio6idx4f7gcvrejrm"
+
+# --------------------------
+# Live deployment
+# -> THESE VARIABLES ARE USED BY THE SCRIPTS
+#
 # Create token mint variables
-EXT_MINT_KEYPAIR=""
-EXT_PROGRAM_KEYPAIR="op://Solana Dev/Solana Program Keys/program-keypair-3"
-EXT_NAME="extUSD"
-EXT_SYMBOL="extUSD"
-EXT_URI="https://green-obedient-albatross-155.mypinata.cloud/ipfs/bafkreiafre7cvdk7p6aa2d5r7c46g7kj3c5xltibptnjaxlyay2xt7uqbm"
+EXT_PROGRAM_KEYPAIR="op://Solana Dev/Solana Program Keys/solana-earner-theta-keypair"
+EXT_MINT_KEYPAIR="op://Solana Dev/Solana Program Keys/dawn-usd"
+EXT_NAME="USD.tel"
+EXT_SYMBOL="USD.tel"
+EXT_URI="https://green-obedient-albatross-155.mypinata.cloud/ipfs/bafkreidyksiobibqsfzjefjlz3nkshgnkk2gangdjio6idx4f7gcvrejrm"

--- a/services/cli/deploy.ts
+++ b/services/cli/deploy.ts
@@ -27,8 +27,8 @@ const opts: shell.ExecOptions & { async: false } = {
 
   program
     .command("deploy-program")
-    .option("-t, --type <type>", "Yield type", "scaled-ui")
-    .option("-e, --extension <name>", "Extension program ID", "USDK")
+    .requiredOption("-t, --type <type>", "Yield type") // no-yield, scaled-ui
+    .requiredOption("-e, --extension <name>", "Extension program ID") // e.g. USDK
     .option("-c, --computePrice <number>", "Compute price", "300000")
     .action(({ type, extension, computePrice }) => {
       const [pid] = keysFromEnv([extension]);
@@ -62,17 +62,21 @@ const opts: shell.ExecOptions & { async: false } = {
 
   program
     .command("set-idl")
-    .option("-t, --type <type>", "Yield type", "scaled-ui")
-    .option("-e, --extension <name>", "Extension program ID", "USDKY")
-    .option("-i, --init", "Extension program ID", false)
+    .requiredOption("-t, --type <type>", "Yield type") // e.g. scaled-ui
+    .requiredOption("-e, --extension <name>", "Extension program ID") // e.g. USDKy
+    .option("--skip-build", "Skip building the program", false) // if deployment was done immediately before, rebuilding is not required.
+    .option("-i, --init", "Upload IDL for the first time", false) // indicates if the data account to store the IDL is created in this transaction.
     .option("-s, --swapProgram", "Update swap program", false)
-    .action(({ type, extension, init, swapProgram }) => {
+    .action(({ type, extension, skipBuild, init, swapProgram }) => {
       const [pid] = keysFromEnv([extension]);
       const pubkey = swapProgram ? EXT_SWAP_PID : pid.publicKey.toBase58();
 
-      console.log(`Building and initializing IDL for extension ${pubkey}`);
+      if (!skipBuild) {
+        console.log(`Building IDL for extension ${pubkey}`);
+        buildProgram(pubkey, type, false, swapProgram);
+      }
 
-      buildProgram(pubkey, type, false, swapProgram);
+      console.log(`Uploading IDL for extension ${pubkey}`);
 
       if (swapProgram) {
         postSwapIDL();
@@ -80,6 +84,8 @@ const opts: shell.ExecOptions & { async: false } = {
       }
 
       postIDL(pubkey, init);
+
+      console.log("IDL successfully uploaded")
     });
 
   program
@@ -582,7 +588,15 @@ function setProgramID(pid: string) {
 }
 
 function keysFromEnv(keys: string[]) {
-  return keys.map((key) =>
-    Keypair.fromSecretKey(Buffer.from(JSON.parse(process.env[key]!))),
-  );
+  const foundKeys = keys.map((key) => {
+    const val = process.env[key];
+    if (val === undefined) {
+      console.error(`environment variable ${key} must be set`);
+      process.exit(1);
+    }
+
+    return Keypair.fromSecretKey(Buffer.from(JSON.parse(val)))
+  });
+
+  return foundKeys;
 }

--- a/services/cli/main.ts
+++ b/services/cli/main.ts
@@ -85,6 +85,8 @@ const mints: { [key: string]: string } = {
     "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y",
   extUkDFf3HLekkxbcZ3XRUizMjbxMJgKBay3p9xGVmg:
     "usdsfJbX78ktZUnoRC7dwvvQz7xH3WdkpGne76gdUia",
+  mextzNVPUbLbvyBwqBqnC5J1SSwjDLjjR4yppf6EBzc:
+    "dawn7ZUF7h7anFuEsDdAU1Y3HYwikwqNMAENZsQJdNL"
 };
 
 const M_MINT = new PublicKey("mzerojk9tg56ebsrEAhfkyc9VgKjTW2zDqp6C5mhjzH");


### PR DESCRIPTION
This PR adds some housekeeping after the Dawn testnet deployment, like adding the extension program ID and token mint to the extensions map.
Additionally, some minor refactors / improvements to the CLI utils have been done, which came up during deployment.

