### PR TITLE
fix: pnpm approve-builds to unblock GitHub actions setup

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ packages:
   - services/**/*
   - tests
 
+allowBuilds:
+  bigint-buffer: false
+  bufferutil: false
+  utf-8-validate: false
+
 catalog:
   '@types/bn.js': 5.2.0
   '@types/bs58': 4.0.1


### PR DESCRIPTION
This PR adds the `pnpm approve-builds` output to unblock the setup o the GitHub actions, which has recently been failing.

