### PR TITLE
Clarify whitelisted_unwrappers comment in ext_swap tests

### DIFF
--- a/tests/unit/ext_swap.test.ts
+++ b/tests/unit/ext_swap.test.ts
@@ -231,7 +231,9 @@ describe("extension swap tests (new)", () => {
       await $.swapProgram.methods
         .unwrap(new BN(1_000))
         .accounts({
-          signer: $.swapperKeypair.publicKey, // must be a whitelisted unwrapper on the swap program
+          // signer (or unwrapAuthority, if given) must be a whitelisted_unwrapper: this only gates
+          // who may receive raw M via unwrap, and is intentionally NOT enforced by swap. See unwrap.rs.
+          signer: $.swapperKeypair.publicKey,
           unwrapAuthority: $.swapProgram.programId, // placeholder for None -> use swap program authority on CPI
           mMint: $.mMint.publicKey,
           mTokenAccount: accounts.ataM,
@@ -252,6 +254,8 @@ describe("extension swap tests (new)", () => {
     it("should swap extension token A to extension token B", async () => {
       const accounts = await getTokenAccounts();
 
+      // swap does NOT check whitelisted_unwrappers (that only gates receiving raw M via unwrap);
+      // swapperKeypair being whitelisted here is incidental, not a requirement of swap.
       await $.swapProgram.methods
         .swap(new BN(1_000), 0)
         .accounts({


### PR DESCRIPTION
## What
Reworded a misleading comment in `tests/unit/ext_swap.test.ts` and added a short note on the swap test.

- **Before:** the unwrap test's comment (`// must be a whitelisted unwrapper on the swap program`) read as if `whitelisted_unwrappers` is a general unwrap gate that should also apply to `swap`.
- **After:** comment states the check only gates who may receive raw M via the standalone `unwrap`, and that `swap` intentionally does not enforce it.

Comments only — no logic, no rebuild.

## Why
An external security report flagged that `swap` "bypasses" `whitelisted_unwrappers`. It does not — `swap` never returns raw M, so the check does not apply, matching the EVM implementation. Verified against `ext_swap/unwrap.rs` (has the check) vs `ext_swap/swap.rs` (no check). This was confirmed intended behavior internally; the test comment was the only thing that implied otherwise, so this closes the ambiguity for the next reader.

## Reviewer notes
- This was the only comment in the repo matching that wording (verified repo-wide).
- Separately (not in this PR): the report also raised a low-severity ScaledUi `calculate_new_index` boundary at `fee_bps=10000`, and the shared permissions-matrix spreadsheet has some account-label inaccuracies on the Unwrap/Swap tabs. Both tracked outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)