### PR TITLE
Fix flaky scaled_ui multiplier test tolerance

### DIFF
--- a/tests/unit/ext_test_harness.ts
+++ b/tests/unit/ext_test_harness.ts
@@ -1248,11 +1248,29 @@ export class ExtensionTest<
       await this.ext.account.extGlobalV2.fetch(this.getExtGlobalAccount())
     ).yieldConfig;
 
-    return (
-      (yieldConfig.lastExtIndex!.toNumber() / 1e12) *
-      (newIndex.toNumber() / yieldConfig.lastMIndex!.toNumber()) **
-        (1 - yieldConfig.feeBps!.toNumber() / 1e4)
-    );
+    const lastExtIndex = yieldConfig.lastExtIndex!;
+    const lastMIndex = yieldConfig.lastMIndex!;
+    const feeBps = yieldConfig.feeBps!.toNumber();
+    const indexScale = new BN(1e12);
+
+    // Mirror calculate_new_index in programs/m_ext/src/utils/conversion.rs
+    // exactly, including its integer-truncating division steps, so the
+    // expected value matches the on-chain result instead of relying on a
+    // float tolerance to absorb the truncation.
+    const mIncreaseFactor = newIndex.mul(indexScale).div(lastMIndex);
+
+    const extIncreaseFactor =
+      feeBps === 0
+        ? mIncreaseFactor.toNumber()
+        : Math.floor(
+            (mIncreaseFactor.toNumber() / 1e12) ** (1 - feeBps / 1e4) * 1e12,
+          );
+
+    const newExtIndex = lastExtIndex
+      .mul(new BN(extIncreaseFactor))
+      .div(indexScale);
+
+    return newExtIndex.toNumber() / 1e12;
   }
 
   public async getCurrentMultiplier(): Promise<number> {


### PR DESCRIPTION
## Summary
CI intermittently failed on `claim_fees unit tests > multiplier not synced, excess collateral exists - success` in `m_ext.test.ts`. The test harness computed the "expected" multiplier using plain JS floating-point math, while the on-chain Rust program truncates twice at 1e-12 precision before and after its exponentiation step. That gap was input-dependent (grew with the randomly-chosen index each run), so it usually stayed under the test's ±2/1e12 tolerance but occasionally exceeded it. This PR makes the JS harness replicate Rust's exact truncation steps so the comparison no longer depends on a tolerance band to absorb a real precision mismatch.

## Before / After
- **Before**: `getNewMultiplier` (`tests/unit/ext_test_harness.ts`) computed `(lastExtIndex/1e12) * (newIndex/lastMIndex) ** (1 - feeBps/1e4)` using plain floats — no truncation, unlike the Rust implementation.
- **Why it broke**: `calculate_new_index` (`programs/m_ext/src/utils/conversion.rs:250-291`) truncates the M-index ratio to 1e-12 via integer `u128` division *before* exponentiating, and truncates again after. The JS side skipped both truncations, so its result was consistently slightly higher than Rust's — usually within ±2/1e12, but not always.
- **After**: `getNewMultiplier` now performs the same two integer floor-divisions as Rust, using `BN` (matching `u128` checked math, no float precision loss), then applies `Math.pow` to the same truncated ratio Rust uses. The only remaining source of difference is `Math.pow` vs Rust's `f64::powf` on identical input — a fixed ~1e-16 relative error per Rust's own code comment, far below the 1e-12 precision the test needs, and still covered by the existing tolerance band.

## Testing
- Ran the previously-failing test 20x in a row (each with a freshly randomized index) — all passed.
- Ran the full `m_ext.test.ts` + `ext_swap.test.ts` suite (586 tests) — all passed.
- Confirmed the fix is not incidental: the eliminated error source scaled with the random index chosen, so removing it (rather than just widening the tolerance) removes the flakiness structurally, not statistically.